### PR TITLE
Fixed package name and roslaunch/rosrun commands error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
-project(m2wr_description)
+project(obstacle_avoidance_bot)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
 # add_compile_options(-std=c++11)

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Xacro is used in the project to clean the URDF code.
 2. Run `catkin_make`
 3. Go to obstacle-avoid.py and make it executable using `chmod +x obstacle_avoidance.py`. No need to do this step if you are using the obstacle-avoid.cpp code.
 3. Open 3 Terminals
-4. Run the command `roslaunch Obstacle-Avoidance-Bot-Using-ROS spawn.launch`. 
-5. In the second terminal run the command `rosrun Obstacle-Avoidance-Bot-Using-ROS obstacle_avoidance.py` or `rosrun Obstacle-Avoidance-Bot-Using-ROS obstacle_avoidance.cpp`
+4. Run the command `roslaunch obstacle_avoidance_bot spawn.launch`. 
+5. In the second terminal run the command `rosrun obstacle_avoidance_bot obstacle_avoidance.py` or `rosrun obstacle_avoidance_bot obstacle_avoidance.cpp`
 6. In last terminal, run the command `rosrun gazebo_ros gazebo --verbose` to start the robot and begin the obstacle avoidance course.
 7. Add blocks in between wherever you want or you can download a world from anywhere else and spawn the bot there.
 

--- a/launch/rviz.launch
+++ b/launch/rviz.launch
@@ -1,9 +1,9 @@
 <launch>
   <arg name="gui" default="true" />
 
-  <arg name="model" default="$(find m2wr_description)/urdf/bot_description.xacro"/>
+  <arg name="model" default="$(find obstacle_avoidance_bot)/urdf/bot_description.xacro"/>
 
-  <param command="$(find xacro)/xacro '$(find m2wr_description)/urdf/bot_description.xacro'" name="robot_description"/>
+  <param command="$(find xacro)/xacro '$(find obstacle_avoidance_bot)/urdf/bot_description.xacro'" name="robot_description"/>
  
   <!-- <arg name="rvizconfig" default="$(find urdf_tutorial)/rviz/urdf.rviz" /> -->
 

--- a/launch/spawn.launch
+++ b/launch/spawn.launch
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  <param command="$(find xacro)/xacro '$(find m2wr_description)/urdf/bot_description.xacro'" name="robot_description"/>
+  <param command="$(find xacro)/xacro '$(find obstacle_avoidance_bot)/urdf/bot_description.xacro'" name="robot_description"/>
 
     <arg name="x" default="0"/>
     <arg name="y" default="0"/>

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <package format="2">
-  <name>m2wr_description</name>
+  <name>obstacle_avoidance_bot</name>
   <version>0.0.0</version>
   <description>The m2wr_description package</description>
 

--- a/urdf/bot_description.xacro
+++ b/urdf/bot_description.xacro
@@ -1,14 +1,14 @@
 <?xml version="1.0" ?>
-<robot name="m2wr" xmlns:xacro="https://www.ros.org/wiki/xacro" >   <!-- this second parameter is importent to make this file a valid xacro file -->
+<robot name="m2wr" xmlns:xacro="https://www.ros.org/wiki/xacro" >   <!-- this second parameter is important to make this file a valid xacro file -->
 
 <!-- in rviz red - x  | green - y | blue -z  -->
 
 <!-- while using odom tf do not forget to do   rosparam set use_sim_time true  as this gives all simulations the same time -->
 
 
-<xacro:include filename="$(find m2wr_description)/urdf/material.xacro" />
-<xacro:include filename="$(find m2wr_description)/urdf/gazebo.xacro" />
-<xacro:include filename="$(find m2wr_description)/urdf/link_joint.xacro" />
+<xacro:include filename="$(find obstacle_avoidance_bot)/urdf/material.xacro" />
+<xacro:include filename="$(find obstacle_avoidance_bot)/urdf/gazebo.xacro" />
+<xacro:include filename="$(find obstacle_avoidance_bot)/urdf/link_joint.xacro" />
 
     
   <link name="link_chassis">


### PR DESCRIPTION
## Overview

Upon build and running the package, I noticed an error with the package name that did not match the actual project name. It seems to have been copied from the template provided by ROS (hence `m2wr_description`).

## Changes Made

- Changed the project name in `CMakeLists.txt` from `m2wr_description` to `obstacle_avoidance_bot`.
- Changed the project name in `package.xml` from `m2wr_description` to `obstacle_avoidance_bot`.
- Fixed the `roslaunch` and `rosrun` commands with the proper package name that comply with ROS packages good practice.